### PR TITLE
Add domain to exclude list

### DIFF
--- a/exclusions.txt
+++ b/exclusions.txt
@@ -3,3 +3,4 @@ headlate.net
 lady-get-mouse.com
 hakimdiver.com
 sxajk.com
+kasya.net


### PR DESCRIPTION
The domain kasya.net is sinkholed and may cause blacklist